### PR TITLE
範囲の例も末尾は添字の末尾のままでよいので修正

### DIFF
--- a/slide.md
+++ b/slide.md
@@ -448,7 +448,7 @@ ___
 ___
 ## for ループ ( 範囲演算子 )
     my @array = ( 1, "hoge", 3 );
-    for my $i (0 .. ($#array + 1)) {
+    for my $i (0 .. ($#array)) {
       print "$array[$i]\n";
     }
 

--- a/src/07-array-for.md
+++ b/src/07-array-for.md
@@ -92,7 +92,7 @@
 
 ## for ループ ( 範囲演算子 )
     my @array = ( 1, "hoge", 3 );
-    for my $i (0 .. ($#array + 1)) {
+    for my $i (0 .. ($#array)) {
       print "$array[$i]\n";
     }
 


### PR DESCRIPTION
添字末尾+1　になっていたので修正しました。
